### PR TITLE
Simplify AkkaGrpcClientFactory

### DIFF
--- a/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
+++ b/codegen/src/main/twirl/templates/ScalaClient/Client.scala.txt
@@ -98,11 +98,6 @@ final class @{service.name}Client(settings: GrpcClientSettings)(implicit mat: Ma
 
 object @{service.name}Client { clientObj =>
 
-  implicit val factory: AkkaGrpcClientFactory[@{service.name}Client] = new AkkaGrpcClientFactory[@{service.name}Client] {
-    override def create(settings: GrpcClientSettings)(implicit mat: Materializer, ex: ExecutionContext): @{service.name}Client =
-      clientObj.apply(settings)(mat, ex)
-  }
-
   def apply(settings: GrpcClientSettings)(implicit mat: Materializer, ex: ExecutionContext): @{service.name}Client =
     new @{service.name}Client(settings)
 

--- a/play-testkit/src/main/scala/akka/grpc/play/api/specs2/ServerGrpcClient.scala
+++ b/play-testkit/src/main/scala/akka/grpc/play/api/specs2/ServerGrpcClient.scala
@@ -4,6 +4,7 @@
 
 package akka.grpc.play.api.specs2
 
+import scala.reflect.ClassTag
 import akka.grpc.internal.{ AkkaGrpcClient, AkkaGrpcClientFactory }
 import akka.grpc.play.AkkaGrpcClientHelpers
 import play.api.test.{ NewForServer, RunningServer }
@@ -17,7 +18,7 @@ import play.api.test.{ NewForServer, RunningServer }
 trait ServerGrpcClient extends AkkaGrpcClientHelpers { this: NewForServer =>
 
   /** Configure the factory by combining the app and the current implicit server information */
-  implicit def configuredAkkaGrpcClientFactory[T <: AkkaGrpcClient: AkkaGrpcClientFactory](implicit running: RunningServer): AkkaGrpcClientFactory.Configured[T] = {
+  implicit def configuredAkkaGrpcClientFactory[T <: AkkaGrpcClient: ClassTag](implicit running: RunningServer): AkkaGrpcClientFactory.Configured[T] = {
     AkkaGrpcClientHelpers.factoryForAppEndpoints(running.app, running.endpoints)
   }
 

--- a/play-testkit/src/main/scala/akka/grpc/scalatestplus/play/ServerGrpcClient.scala
+++ b/play-testkit/src/main/scala/akka/grpc/scalatestplus/play/ServerGrpcClient.scala
@@ -8,6 +8,7 @@ import akka.grpc.internal.{ AkkaGrpcClient, AkkaGrpcClientFactory }
 import akka.grpc.play.AkkaGrpcClientHelpers
 import org.scalatestplus.play.NewServerProvider
 import play.api.test.RunningServer
+import scala.reflect.ClassTag
 
 /**
  * Helpers to test gRPC clients with Play using ScalaTest.
@@ -17,7 +18,7 @@ import play.api.test.RunningServer
 trait ServerGrpcClient extends AkkaGrpcClientHelpers { this: NewServerProvider =>
 
   /** Configure the factory by combining the current app and server information */
-  implicit def configuredAkkaGrpcClientFactory[T <: AkkaGrpcClient: AkkaGrpcClientFactory](implicit running: RunningServer): AkkaGrpcClientFactory.Configured[T] = {
+  implicit def configuredAkkaGrpcClientFactory[T <: AkkaGrpcClient: ClassTag](implicit running: RunningServer): AkkaGrpcClientFactory.Configured[T] = {
     AkkaGrpcClientHelpers.factoryForAppEndpoints(running.app, running.endpoints)
   }
 


### PR DESCRIPTION
This seems to make things a little simpler, moving some things from the 'main' code to the testkit (at the expense of a small bit of reflection, but that seems safe since it's against generated code). WDYT?